### PR TITLE
`/signin` エンドポイントのpostメソッドに関する詳細設計を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -47,6 +47,12 @@ components:
         エラーに関する対人可読な短い説明文が格納される。
 
         https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+    problemDetailsDetail:
+      type: string
+      description: |
+        エラーに関する対人可読な説明文が格納される。
+
+        https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
 
 paths:
   /signin:
@@ -126,10 +132,18 @@ paths:
 
             https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
           content:
-            application/json:
+            application/problem+json:
               schema:
                 type: object
                 properties:
+                  status:
+                    $ref: '#/components/schemas/problemDetailsStatus'
+                  title:
+                    $ref: '#/components/schemas/problemDetailsTitle'
+                  detail:
+                    # NOTE: 役割としては https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 に定義されている任意のフィールドである `error_description` と同様である。
+                    # 場合によっては、互換性のために値は `detail` フィールドと同値である `error_description` フィールドを追加する必要があるかもしれない。
+                    $ref: '#/components/schemas/problemDetailsDetail'
                   error:
                     type: string
                     enum:
@@ -138,10 +152,9 @@ paths:
                       - unsupported_grant_type
                       - invalid_scope
                     description: 失敗した理由を示すエラーコードである。
-                  error_description:
-                    type: string
-                    description: 失敗した理由に関する対人可読な追加情報である。
                 required:
+                  - status
+                  - title
                   - error
   /signout:
     delete:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -124,10 +124,9 @@ paths:
                     type: string
                     enum:
                       - invalid_request
-                      - invalid_client
                       - invalid_grant
-                      - unauthorized_client
                       - unsupported_grant_type
+                      - invalid_scope
                     description: 失敗した理由を示すエラーコードである。
                   error_description:
                     type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -41,7 +41,7 @@ components:
 paths:
   /signin:
     post:
-      summary: ログインしたユーザにアクセストークンを発行する。
+      summary: 認証したユーザにアクセストークンを発行する。
       description: OAuth2.0のResource Owner Password Credential grant方式で、かつクライアント認証なしでのアクセストークンの発行を行う。
       operationId: LoginUser
       requestBody:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -60,7 +60,7 @@ paths:
                   enum:
                     - password
                   description: 認可サーバに要求するグラントのタイプである。ここではResource Owner Password Credential grant方式を利用するため、値は `password` である必要がある。
-                user_name:
+                username:
                   type: string
                   description: アクセストークンの要求に利用するリソースオーナーのユーザ名である。
                 password:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13,11 +13,9 @@ components:
       type: object
       properties:
         status:
-          type: number
-          description: エラー発生時のHTTPステータスと同じ値になる。
+          $ref: '#/components/schemas/problemDetailsStatus'
         title:
-          type: string
-          description: エラーに関する対人可読な短い説明文が格納される。
+          $ref: '#/components/schemas/problemDetailsTitle'
         errors:
           type: array
           items:
@@ -37,6 +35,18 @@ components:
       required:
         - status
         - errors
+    problemDetailsStatus:
+      type: integer
+      description: |
+        エラー発生時のHTTPステータスと同じ値になる。
+
+        https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+    problemDetailsTitle:
+      type: string
+      description: |
+        エラーに関する対人可読な短い説明文が格納される。
+
+        https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
 
 paths:
   /signin:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,9 +95,6 @@ paths:
                     type: integer
                     format: int64
                     description: アクセストークンが発行されてから失効するまでの有効期間を示す。単位は秒である。
-                  refresh_token:
-                    type: string
-                    description: 発行されたアクセストークンと同じグラントを利用して新しいアクセストークンを発行するためのトークンである。
                   scope:
                     type: string
                     description: 発行されたアクセストークンのスコープを示す。省略されている場合は、リクエストしたスコープと同じであることを意味する。
@@ -111,8 +108,7 @@ paths:
                     {
                       "access_token": "zNxoOIF7F9FEifI2",
                       "token_type": "bearer",
-                      "expires_in": 3600,
-                      "refresh_token": "4iIJIeL9iiFBBFMn"
+                      "expires_in": 3600
                     }
         '400':
           description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,7 +133,7 @@ paths:
                     type: string
                     description: 失敗した理由に関する対人可読な追加情報である。
                 required:
-                  - erorr
+                  - error
   /signout:
     delete:
       summary: ユーザとしてログアウトする

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -41,7 +41,103 @@ components:
 paths:
   /signin:
     post:
-      summary: ユーザとしてログインする
+      summary: ログインしたユーザにアクセストークンを発行する。
+      description: OAuth2.0のResource Owner Password Credential grant方式で、かつクライアント認証なしでのアクセストークンの発行を行う。
+      operationId: LoginUser
+      requestBody:
+        description: |
+          OAuth2.0のResource Owner Password Credential grant方式によるアクセストークンリクエスト時に必要となるパラメータを格納する。
+          なお、UTF-8でエンコードされている必要がある。
+
+          https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.2
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                grant_type:
+                  type: string
+                  enum:
+                    - password
+                  description: 認可サーバに要求するグラントのタイプである。ここではResource Owner Password Credential grant方式を利用するため、値は `password` である必要がある。
+                user_name:
+                  type: string
+                  description: アクセストークンの要求に利用するリソースオーナーのユーザ名である。
+                password:
+                  type: string
+                  description: アクセストークンの要求に利用するリソースオーナーのパスワードである。
+                scope:
+                  type: string
+                  description: 要求するアクセストークンのスコープである。
+              required:
+                - grant_type
+                - user_name
+                - password
+        required: true
+      responses:
+        '200':
+          description: |
+            ログインに成功してアクセストークンが発行されたことを意味する。
+
+            https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string
+                    description: 認可サーバから発行されたアクセストークンである。
+                  token_type:
+                    type: string
+                    description: 発行されたアクセストークンの種類である。トークンをどのようにして利用するかを示す。
+                  expires_in:
+                    type: integer
+                    format: int64
+                    description: アクセストークンが発行されてから失効するまでの有効期間を示す。単位は秒である。
+                  refresh_token:
+                    type: string
+                    description: 発行されたアクセストークンと同じグラントを利用して新しいアクセストークンを発行するためのトークンである。
+                  scope:
+                    type: string
+                    description: 発行されたアクセストークンのスコープを示す。省略されている場合は、リクエストしたスコープと同じであることを意味する。
+                required:
+                  - access_token
+                  - token_type
+              examples:
+                successful_login:
+                  summary: ログインに成功してアクセストークンが発行された
+                  value:
+                    {
+                      "access_token": "zNxoOIF7F9FEifI2",
+                      "token_type": "bearer",
+                      "expires_in": 3600,
+                      "refresh_token": "4iIJIeL9iiFBBFMn"
+                    }
+        '400':
+          description: |
+            ログインに失敗してアクセストークンが発行されなかったことを意味する。
+
+            https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - invalid_request
+                      - invalid_client
+                      - invalid_grant
+                      - unauthorized_client
+                      - unsupported_grant_type
+                    description: 失敗した理由を示すエラーコードである。
+                  error_description:
+                    type: string
+                    description: 失敗した理由に関する対人可読な追加情報である。
+                required:
+                  - erorr
   /signout:
     delete:
       summary: ユーザとしてログアウトする


### PR DESCRIPTION
# 概要

`/signin` エンドポイントのPOSTメソッドに関する詳細設計をOpenAPI v3.1.0に沿って記述した。

リクエストやレスポンスのパラメータはOAuth 2.0のRFCを参考に記述した。

エラーレスポンスは、Problem Detailsを参考に記述した。あくまで参考なので、Problem Detailsでは必須になっているパラメータを省略していたりする。

# 関連知識

- OpenAPI Specification v3.1.0 - https://spec.openapis.org/oas/v3.1.0
- JSON Schema - https://json-schema.org
- The OAuth 2.0 Authorization Framework - https://datatracker.ietf.org/doc/html/rfc6749

# 補足

本プルリクは #3 の後続である。 #3 のマージ後にベースブランチをmainに変更する。