### PR TITLE
`/signout` エンドポイントのpostメソッドに関する詳細設計を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -174,7 +174,6 @@ paths:
                   type: string
                   enum:
                     - access_token
-                    - refresh_token
                   description: 失効させたいトークンの種類
               required:
                 - token

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -195,19 +195,26 @@ paths:
 
             よって、これらの前提が変更されれば、ここでサポートされるエラーコードも変更される必要がある。
           content:
-            application/json:
+            application/problem+json:
               schema:
                 type: object
                 properties:
+                  status:
+                    $ref: '#/components/schemas/problemDetailsStatus'
+                  title:
+                    $ref: '#/components/schemas/problemDetailsTitle'
+                  detail:
+                    # NOTE: 役割としては https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 に定義されている任意のフィールドである `error_description` と同様である。
+                    # 場合によっては、互換性のために値は `detail` フィールドと同値である `error_description` フィールドを追加する必要があるかもしれない。
+                    $ref: '#/components/schemas/problemDetailsDetail'
                   error:
                     type: string
                     enum:
                       - invalid_request
                     description: 失敗した理由を示すエラーコードである。
-                  error_description:
-                    type: string
-                    description: 失敗した理由に関する対人可読な追加情報である。
                 required:
+                  - status
+                  - title
                   - error
   /files:
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -186,6 +186,15 @@ paths:
             トークンの失効に失敗したことを意味する。
 
             https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1
+
+            上記のURI先に記載されているエラーコードのうち、ここではサポートしていないものがある。
+            これは以下のような理由による。
+
+            - クライアント登録もクライアント認証もないので、クライアント関連のエラーは発生しない。
+            - トークンしか送信しないのでグラント関連のエラーは発生しない。
+            - アクセストークンのみを発行かつアクセストークンの失効をサポートしている都合上、サポートしていないタイプのトークンの送信が発生しないので、トークンタイプ関連のエラーは発生しない。
+
+            よって、これらの前提が変更されれば、ここでサポートされるエラーコードも変更される必要がある。
           content:
             application/json:
               schema:
@@ -195,11 +204,6 @@ paths:
                     type: string
                     enum:
                       - invalid_request
-                      - invalid_client
-                      - invalid_grant
-                      - unauthorized_client
-                      - unsupported_grant_type
-                      - unsupported_token_type
                     description: 失敗した理由を示すエラーコードである。
                   error_description:
                     type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -174,7 +174,7 @@ paths:
                   type: string
                   enum:
                     - access_token
-                  description: 失効させたいトークンの種類
+                  description: 失効させたいトークンの種類を示す。サーバ上でトークンを検索する際に利用される補助情報であり、最終的にサーバ上でトークンを発見できるかには影響を与えない。
               required:
                 - token
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -157,8 +157,55 @@ paths:
                   - title
                   - error
   /signout:
-    delete:
-      summary: ユーザとしてログアウトする
+    post:
+      summary: 発行したアクセストークンを失効させる。
+      operationId: LogoutUser
+      requestBody:
+        description: https://datatracker.ietf.org/doc/html/rfc7009#section-2.1
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                  description: クライアントが失効させたいトークン
+                token_type_hint:
+                  type: string
+                  enum:
+                    - access_token
+                    - refresh_token
+                  description: 失効させたいトークンの種類
+              required:
+                - token
+      responses:
+        '200':
+          description: トークンの失効に成功したことを示す。また、不正なトークンを送信した場合もこのレスポンスを返す。
+        '400':
+          description: |
+            トークンの失効に失敗したことを意味する。
+
+            https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - invalid_request
+                      - invalid_client
+                      - invalid_grant
+                      - unauthorized_client
+                      - unsupported_grant_type
+                      - unsupported_token_type
+                    description: 失敗した理由を示すエラーコードである。
+                  error_description:
+                    type: string
+                    description: 失敗した理由に関する対人可読な追加情報である。
+                required:
+                  - erorr
   /files:
     get:
       summary: アップロードされたファイル一覧を返す

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -208,7 +208,7 @@ paths:
                     type: string
                     description: 失敗した理由に関する対人可読な追加情報である。
                 required:
-                  - erorr
+                  - error
   /files:
     get:
       summary: アップロードされたファイル一覧を返す


### PR DESCRIPTION
# 概要

`/signout` エンドポイントのPOSTメソッドに関する詳細設計をOpenAPI v3.1.0に沿って記述した。

リクエストやレスポンスのパラメータはOAuth 2.0 Token RevocationのRFCを参考に記述した。

# 関連知識

- OpenAPI Specification v3.1.0 - https://spec.openapis.org/oas/v3.1.0
- JSON Schema - https://json-schema.org
- OAuth 2.0 Token Revocation - https://datatracker.ietf.org/doc/html/rfc7009

# 補足

本プルリクは #4 の後続である。 #4 のマージ後にベースブランチをmainに変更する。