### PR TITLE
`/files` エンドポイントのGETメソッドに関する詳細設計を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -218,9 +218,61 @@ paths:
       summary: ユーザがアップロードしたファイル一覧を返す。
       description: 送信されたアクセストークンを発行されたユーザがアップロードしたファイルの一覧を返す。
       operationId: GetFiles
+      parameters:
+        - name: page
+          in: query
+          description: 要求するページ番号を指定する。
+          schema:
+            type: integer
+            format: int64
+            default: 1
+        - name: per
+          in: query
+          description: 1ページに含めるファイルの情報の総数を指定する。ただし、特に最終ページについては、必ずしもこのパラメータで指定した数のファイルの情報が含まれるとは限らない。
+          schema:
+            type: integer
+            format: int64
+            default: 20
+        - name: order
+          in: query
+          description: 返すファイル情報の並びを決定する際の順序を指定する。
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: asc
+        - name: orderby
+          in: query
+          description: 返すファイル情報をどのような基準で並べるか指定する。
+          schema:
+            type: string
+            enum:
+              - name
+              - description
+              - size
+              - created_at
+              - changed_at
+            default: created_at
       responses:
         '200':
           description: ユーザがアップロードしたファイル一覧の取得に成功したことを意味する。
+          headers:
+            link:
+              description: |
+                ページネーション用のリンクを格納する。
+
+                この値の仕様はGitHubのREST APIにおけるページネーションと同様である。
+                https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers
+              schema:
+                type: string
+              examples:
+                on_first_page:
+                  summary: 先頭ページを返す場合。
+                  value: link: <http://localhost:<PORT>/files?page=2>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"
+                on_middle_page:
+                  summary: 中間ページを返す場合。
+                  value: link: <http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -270,29 +270,62 @@ paths:
                         "changed_at": "2020-10-12T11:10:30+00:00"
                       }
                     ]
-        '401':
-          description: ユーザがアップロードしたファイル一覧の取得に失敗したことを意味する。
+        '400':
+          description: 必須パラメータの不足、サポートされていないパラメータ名や値、重複したパラメータ名、複数ないし正しくない認証方法の利用を意味する。
           content:
             application/problem+json:
               schema:
                 description: |
                   https://datatracker.ietf.org/doc/html/rfc7807
                   https://datatracker.ietf.org/doc/html/rfc6749#section-7.2
+                  https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
                 type: object
                 properties:
                   status:
-                    type: integer
-                    description: エラー発生時のHTTPステータスと同じ値になる。
+                    $ref: '#/components/schemas/problemDetailsStatus'
                   title:
-                    type: string
-                    description: エラーに関する対人可読な短い説明文が格納される。
+                    $ref: '#/components/schemas/problemDetailsTitle'
                   error:
-                    description: https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml
                     type: string
                     enum:
                       - invalid_request
+                    description: エラー内容を示すエラーコードが格納される。
+                required:
+                  - status
+                  - title
+                  - error
+              examples:
+                missing_required_parameters:
+                  summary: 必須パラメータが不足している。
+                  value:
+                    {
+                      "status": 400,
+                      "title": "Missing required parameters",
+                      "error": "invalid_request"
+                    }
+        '401':
+          description: |
+            アクセストークンがない、あるいは失効や有効期限切れなどによる有効でないアクセストークンによるアクセスを意味する。
+
+            なお、トークンがない場合や認証方式が誤っている場合は、レスポンスボディには何も含まれないことに注意する。
+            この仕様は [3.1. Error Codes | OAuth 2.0 Bearer Token Usage](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1) で推奨されている。
+          content:
+            application/problem+json:
+              schema:
+                description: |
+                  https://datatracker.ietf.org/doc/html/rfc7807
+                  https://datatracker.ietf.org/doc/html/rfc6749#section-7.2
+                  https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/problemDetailsStatus'
+                  title:
+                    $ref: '#/components/schemas/problemDetailsTitle'
+                  error:
+                    type: string
+                    enum:
                       - invalid_token
-                      - insufficient_scope
                     description: エラー内容を示すエラーコードが格納される。
                 required:
                   - status
@@ -306,6 +339,44 @@ paths:
                       "status": 401,
                       "title": "An access with an invalid access token",
                       "error": "invalid_token"
+                    }
+        '403':
+          description: 送信したアクセストークンの権限の不足を意味する。
+          content:
+            application/problem+json:
+              schema:
+                description: |
+                  https://datatracker.ietf.org/doc/html/rfc7807
+                  https://datatracker.ietf.org/doc/html/rfc6749#section-7.2
+                  https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/problemDetailsStatus'
+                  title:
+                    $ref: '#/components/schemas/problemDetailsTitle'
+                  error:
+                    type: string
+                    enum:
+                      - insufficient_scope
+                    description: エラー内容を示すエラーコードが格納される。
+                  scope:
+                    type: string
+                    description: 保護されたリソースへのアクセスに必要なスコープが格納される。
+                required:
+                  - status
+                  - title
+                  - error
+                  - scope
+              examples:
+                insufficient_scope:
+                  summary: アクセストークンの権限が不足している場合。
+                  value:
+                    {
+                      "status": 403,
+                      "title": "The access token only has insufficient scopes",
+                      "error": "insufficient_scope",
+                      "scope": "write"
                     }
       security:
         - bearer: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -248,6 +248,7 @@ paths:
           schema:
             type: string
             enum:
+              - id
               - name
               - description
               - size
@@ -280,6 +281,10 @@ paths:
                 items:
                   type: object
                   properties:
+                    id:
+                      description: アップロードしたファイルのID
+                      type: string
+                      format: uuid
                     name:
                       description: アップロードしたファイルの名前
                       type: string
@@ -299,6 +304,7 @@ paths:
                       type: string
                       format: date-time
                   required:
+                    - id
                     - name
                     - size
                     - created_at
@@ -309,6 +315,7 @@ paths:
                   value:
                     [
                       {
+                        "id": "76DA18B4-7CF0-48C1-A33D-2FFA0A4B345A",
                         "name": "sample01.txt",
                         "description": "My diary",
                         "size": 1024,
@@ -316,6 +323,7 @@ paths:
                         "changed_at": "2023-05-25T23:07:39+00:00"
                       },
                       {
+                        "id": "9BD3BEA3-67E7-401A-9A45-C6CAB38A052A",
                         "name": "sample02.png",
                         "size": 1048576,
                         "created_at": "2020-10-12T11:10:30+00:00",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -53,6 +53,10 @@ components:
         エラーに関する対人可読な説明文が格納される。
 
         https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: bearer
 
 paths:
   /signin:
@@ -211,7 +215,100 @@ paths:
                   - error
   /files:
     get:
-      summary: アップロードされたファイル一覧を返す
+      summary: ユーザがアップロードしたファイル一覧を返す。
+      description: 送信されたアクセストークンを発行されたユーザがアップロードしたファイルの一覧を返す。
+      operationId: GetFiles
+      responses:
+        '200':
+          description: ユーザがアップロードしたファイル一覧の取得に成功したことを意味する。
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: アップロードしたファイルの名前
+                      type: string
+                    description:
+                      description: アップロードしたファイルの説明文
+                      type: string
+                    size:
+                      description: アップロードしたファイルの容量
+                      type: integer
+                      format: int64
+                    created_at:
+                      description: ファイルをアップロードした日時
+                      type: string
+                      format: date-time
+                    changed_at:
+                      description: アップロードしたファイルの最終更新日時
+                      type: string
+                      format: date-time
+                  required:
+                    - name
+                    - size
+                    - created_at
+                    - changed_at
+              examples:
+                files:
+                  summary: サンプルファイル群
+                  value:
+                    [
+                      {
+                        "name": "sample01.txt",
+                        "description": "My diary",
+                        "size": 1024,
+                        "created_at": "2020-10-12T11:20:44+00:00",
+                        "changed_at": "2023-05-25T23:07:39+00:00"
+                      },
+                      {
+                        "name": "sample02.png",
+                        "size": 1048576,
+                        "created_at": "2020-10-12T11:10:30+00:00",
+                        "changed_at": "2020-10-12T11:10:30+00:00"
+                      }
+                    ]
+        '401':
+          description: ユーザがアップロードしたファイル一覧の取得に失敗したことを意味する。
+          content:
+            application/problem+json:
+              schema:
+                description: |
+                  https://datatracker.ietf.org/doc/html/rfc7807
+                  https://datatracker.ietf.org/doc/html/rfc6749#section-7.2
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    description: エラー発生時のHTTPステータスと同じ値になる。
+                  title:
+                    type: string
+                    description: エラーに関する対人可読な短い説明文が格納される。
+                  error:
+                    description: https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml
+                    type: string
+                    enum:
+                      - invalid_request
+                      - invalid_token
+                      - insufficient_scope
+                    description: エラー内容を示すエラーコードが格納される。
+                required:
+                  - status
+                  - title
+                  - error
+              examples:
+                invalid_token:
+                  summary: 不正なトークンによるアクセスを試みた場合。
+                  value:
+                    {
+                      "status": 401,
+                      "title": "An access with an invalid access token",
+                      "error": "invalid_token"
+                    }
+      security:
+        - bearer: []
     post:
       summary: 新しいファイルをアップロードする
   /files/{fileId}:


### PR DESCRIPTION
# 概要

`/files` エンドポイントのGETメソッドに関する詳細設計をOpenAPI v3.1.0に沿って記述した。

エラーレスポンスのパラメータは、OAuth 2.0やProblem DetailsのRFCを参考に記述した。

# 関連知識

- OpenAPI Specification v3.1.0 - https://spec.openapis.org/oas/v3.1.0
- JSON Schema - https://json-schema.org
- OAuth Parameters - https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml

# 補足

本プルリクは #5 の後続である。 #5 のマージ後にベースブランチをmainに変更する。