### PR TITLE
ファイル関連のデータを取得するためのエンドポイントに関する説明を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,7 +7,6 @@ info:
   version: 0.0.0
 
 components:
-  parameters:
   schemas:
     fileProperties:
       type: object
@@ -103,7 +102,35 @@ components:
         エラーに関する対人可読な説明文が格納される。
 
         https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+    problemDetailsInstance:
+      type: string
+      format: uri-reference
+      description: |
+        エラーが発生したリソースへの相対URIが格納される。
+
+        https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
   responses:
+    notFound:
+      description: リソースが存在しないことを意味する。
+      content:
+        application/problem+json:
+          schema:
+            description: |
+              https://datatracker.ietf.org/doc/html/rfc7807
+              https://datatracker.ietf.org/doc/html/rfc6749#section-7.2
+              https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
+            type: object
+            properties:
+              status:
+                $ref: '#/components/schemas/problemDetailsStatus'
+              title:
+                $ref: '#/components/schemas/problemDetailsTitle'
+              instance:
+                $ref: '#/components/schemas/problemDetailsInstance'
+            required:
+              - status
+              - title
+              - instance
     bearerBadRequest:
       description: 必須パラメータの不足、サポートされていないパラメータ名や値、重複したパラメータ名、複数ないし正しくない認証方法の利用を意味する。
       content:
@@ -212,6 +239,11 @@ components:
                   "error": "insufficient_scope",
                   "scope": "write"
                 }
+  parameters:
+    fileId:
+      name: fileId
+      in: path
+      required: true
   securitySchemes:
     bearer:
       type: http
@@ -520,13 +552,72 @@ paths:
         - bearer: []
   /files/{fileId}:
     get:
-      summary: ファイル名やその説明文、あるいはファイル自身などファイルの情報を返す
+      summary: /files/{fileId}/binary のエイリアスである。
+      operationId: GetFile
+      responses:
+        '200':
+          description: ファイルのバイナリを取得に成功したことを意味する。
+          content:
+            application/octet-stream: {}
+        '400':
+          $ref: '#/components/responses/bearerBadRequest'
+        '401':
+          $ref: '#/components/responses/bearerUnauthorized'
+        '403':
+          $ref: '#/components/responses/bearerForbidden'
+        '404':
+          $ref: '#/components/responses/notFound'
+      security:
+        - bearer: []
     patch:
       summary: ファイルの情報を更新する
     delete:
       summary: アップロードされているファイルを削除する
     parameters:
-      - name: fileId
+      - $ref: "#/components/parameters/fileId"
+  /files/{fileId}/properties:
+    get:
+      summary: ファイル名やその説明文などファイルの情報を返す
+      operationId: GetFileProperties
+        '200':
+          description: ファイルの情報の取得に成功したことを意味する。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/fileProperties'
+        '400':
+          $ref: '#/components/responses/bearerBadRequest'
+        '401':
+          $ref: '#/components/responses/bearerUnauthorized'
+        '403':
+          $ref: '#/components/responses/bearerForbidden'
+        '404':
+          $ref: '#/components/responses/notFound'
+      security:
+        - bearer: []
+    parameters:
+      - $ref: "#/components/parameters/fileId"
+  /files/{fileId}/binary:
+    get:
+      summary: ファイル自身を返す
+      operationId: GetFileBinary
+      responses:
+        '200':
+          description: ファイルのバイナリを取得に成功したことを意味する。
+          content:
+            application/octet-stream: {}
+        '400':
+          $ref: '#/components/responses/bearerBadRequest'
+        '401':
+          $ref: '#/components/responses/bearerUnauthorized'
+        '403':
+          $ref: '#/components/responses/bearerForbidden'
+        '404':
+          $ref: '#/components/responses/notFound'
+      security:
+        - bearer: []
+    parameters:
+      - $ref: "#/components/parameters/fileId"
   /user:
     get:
       summary: 現在自分がログインしているユーザの情報を返す

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -552,7 +552,7 @@ paths:
         - bearer: []
   /files/{fileId}:
     get:
-      summary: /files/{fileId}/binary のエイリアスである。
+      summary: /files/{fileId}/content のエイリアスである。
       operationId: GetFile
       responses:
         '200':
@@ -597,10 +597,10 @@ paths:
         - bearer: []
     parameters:
       - $ref: "#/components/parameters/fileId"
-  /files/{fileId}/binary:
+  /files/{fileId}/content:
     get:
       summary: ファイル自身を返す
-      operationId: GetFileBinary
+      operationId: GetFileContent
       responses:
         '200':
           description: ファイルのバイナリを取得に成功したことを意味する。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -553,6 +553,13 @@ paths:
   /files/{fileId}:
     get:
       summary: /files/{fileId}/content のエイリアスである。
+      description: |
+        `/files/{fileId}` へのGETリクエストは、`/files{fileId}/content` へのGETリクエストのエイリアスになっている。
+
+        論理的にはファイルリソース(`/files/{fileId}`)は、ファイルの実態であるバイナリ(`/files{fileId}/content`)とそのメタデータ(`/files{fileId}/properties`)から構成されている。
+        また、実用上においても、例えばファイルのバイナリへの直リンクを利用したいといった状況が考えられるため、先の2つのデータが別々のURIで提供する。
+        一方で、直感的には、ファイルリソースは、ファイルの実態であるバイナリとも解釈可能である。
+        よって、ファイルリソースへのGETリクエストでは、ファイルの実態であるバイナリへのGETリクエストと同等であるとして扱っている。
       operationId: GetFile
       responses:
         '200':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -131,6 +131,64 @@ components:
               - status
               - title
               - instance
+    unprocessableEntity:
+      description: パラメータのバリデーションエラーが発生したことを意味する。
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            patch_files_fileId_validation_errors:
+              summary: ファイルのメタデータの更新時にいくつかのバリデーションが発生した。
+              value:
+                {
+                  "status": 422,
+                  "title": "Some validation errors for the file",
+                  "errors": [
+                    { "name": "description", "reason": "Too long" },
+                    { "name": "size", "reason": "Too large" }
+                  ]
+                }
+            post_users_empty_name:
+              summary: ユーザの表示名が空白である。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "name", "reason": "The name is empty." }
+                  ]
+                }
+            post_users_invalid_email:
+              summary: メールアドレスが不正な形式である。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "email", "reason": "The email has an invalid form." }
+                  ]
+                  }
+            post_users_not_unique_email:
+              summary: 同じメールアドレスが既に登録されている。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "email", "reason": "The email has already been registered." }
+                  ]
+                }
+            post_users_too_short_password:
+              summary: パスワードが短すぎる。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "password", "reason": "The password is too short." }
+                  ]
+                }
     bearerBadRequest:
       description: 必須パラメータの不足、サポートされていないパラメータ名や値、重複したパラメータ名、複数ないし正しくない認証方法の利用を意味する。
       content:
@@ -533,21 +591,7 @@ paths:
         '403':
           $ref: '#/components/responses/bearerForbidden'
         '422':
-          description: ポストしたパラメータのバリデーションエラーが発生したことを意味する。
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/error'
-              examples:
-                validation_errors:
-                  {
-                    "status": 422,
-                    "title": "Some validation errors for the file",
-                    "errors": [
-                      { "name": "description", "reason": "Too long" },
-                      { "name": "size", "reason": "Too large" }
-                    ]
-                  }
+          $ref: '#/components/responses/unprocessableEntity'
       security:
         - bearer: []
   /files/{fileId}:
@@ -678,52 +722,7 @@ paths:
         '201':
           description: ユーザ作成に成功したことを意味する。
         '422':
-          description: ユーザ作成に失敗したことを意味する。
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/error'
-              examples:
-                empty_name:
-                  summary: ユーザの表示名が空白である。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "name", "reason": "The name is empty." }
-                      ]
-                    }
-                invalid_email:
-                  summary: メールアドレスが不正な形式である。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "email", "reason": "The email has an invalid form." }
-                      ]
-                    }
-                not_unique_email:
-                  summary: 同じメールアドレスが既に登録されている。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "email", "reason": "The email has already been registered." }
-                      ]
-                    }
-                too_short_password:
-                  summary: パスワードが短すぎる。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "password", "reason": "The password is too short." }
-                      ]
-                    }
+          $ref: '#/components/responses/unprocessableEntity'
     patch:
       summary: 現在自分がログインしているユーザの情報を更新する
     delete:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -551,31 +551,6 @@ paths:
       security:
         - bearer: []
   /files/{fileId}:
-    get:
-      summary: /files/{fileId}/content のエイリアスである。
-      description: |
-        `/files/{fileId}` へのGETリクエストは、`/files{fileId}/content` へのGETリクエストのエイリアスになっている。
-
-        論理的にはファイルリソース(`/files/{fileId}`)は、ファイルの実態であるバイナリ(`/files{fileId}/content`)とそのメタデータ(`/files{fileId}/properties`)から構成されている。
-        また、実用上においても、例えばファイルのバイナリへの直リンクを利用したいといった状況が考えられるため、先の2つのデータが別々のURIで提供する。
-        一方で、直感的には、ファイルリソースは、ファイルの実態であるバイナリとも解釈可能である。
-        よって、ファイルリソースへのGETリクエストでは、ファイルの実態であるバイナリへのGETリクエストと同等であるとして扱っている。
-      operationId: GetFile
-      responses:
-        '200':
-          description: ファイルのバイナリを取得に成功したことを意味する。
-          content:
-            application/octet-stream: {}
-        '400':
-          $ref: '#/components/responses/bearerBadRequest'
-        '401':
-          $ref: '#/components/responses/bearerUnauthorized'
-        '403':
-          $ref: '#/components/responses/bearerForbidden'
-        '404':
-          $ref: '#/components/responses/notFound'
-      security:
-        - bearer: []
     patch:
       summary: ファイルの情報を更新する
     delete:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -282,7 +282,7 @@ paths:
                   description: 要求するアクセストークンのスコープである。
               required:
                 - grant_type
-                - user_name
+                - username
                 - password
         required: true
       responses:


### PR DESCRIPTION
# 概要

ファイルのバイナリや名前やIDなどの関連データを取得するためのエンドポイント群に関する詳細設計をOpenAPI v3.1.0に沿って記述した。

エラーレスポンスのパラメータは、OAuth 2.0やProblem DetailsのRFCを参考に記述した。

# 関連知識

- OpenAPI Specification v3.1.0 - https://spec.openapis.org/oas/v3.1.0
- JSON Schema - https://json-schema.org
- OAuth Parameters - https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml

# 補足

本プルリクは #7 の後続である。 #7 のマージ後にベースブランチをmainに変更する。