### PR TITLE
共通コンポーネントへのUnprocessable Entity用スキーマの抽出

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -131,6 +131,64 @@ components:
               - status
               - title
               - instance
+    unprocessableEntity:
+      description: パラメータのバリデーションエラーが発生したことを意味する。
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            patch_files_fileId_validation_errors:
+              summary: ファイルのメタデータの更新時にいくつかのバリデーションが発生した。
+              value:
+                {
+                  "status": 422,
+                  "title": "Some validation errors for the file",
+                  "errors": [
+                    { "name": "description", "reason": "Too long" },
+                    { "name": "size", "reason": "Too large" }
+                  ]
+                }
+            post_users_empty_name:
+              summary: ユーザの表示名が空白である。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "name", "reason": "The name is empty." }
+                  ]
+                }
+            post_users_invalid_email:
+              summary: メールアドレスが不正な形式である。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "email", "reason": "The email has an invalid form." }
+                  ]
+                  }
+            post_users_not_unique_email:
+              summary: 同じメールアドレスが既に登録されている。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "email", "reason": "The email has already been registered." }
+                  ]
+                }
+            post_users_too_short_password:
+              summary: パスワードが短すぎる。
+              value:
+                {
+                  "status": 422,
+                  "title": "Validation error for user",
+                  "errors": [
+                    { "name": "password", "reason": "The password is too short." }
+                  ]
+                }
     bearerBadRequest:
       description: 必須パラメータの不足、サポートされていないパラメータ名や値、重複したパラメータ名、複数ないし正しくない認証方法の利用を意味する。
       content:
@@ -533,21 +591,7 @@ paths:
         '403':
           $ref: '#/components/responses/bearerForbidden'
         '422':
-          description: ポストしたパラメータのバリデーションエラーが発生したことを意味する。
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/error'
-              examples:
-                validation_errors:
-                  {
-                    "status": 422,
-                    "title": "Some validation errors for the file",
-                    "errors": [
-                      { "name": "description", "reason": "Too long" },
-                      { "name": "size", "reason": "Too large" }
-                    ]
-                  }
+          $ref: '#/components/responses/unprocessableEntity'
       security:
         - bearer: []
   /files/{fileId}:
@@ -678,52 +722,7 @@ paths:
         '201':
           description: ユーザ作成に成功したことを意味する。
         '422':
-          description: ユーザ作成に失敗したことを意味する。
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/error'
-              examples:
-                empty_name:
-                  summary: ユーザの表示名が空白である。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "name", "reason": "The name is empty." }
-                      ]
-                    }
-                invalid_email:
-                  summary: メールアドレスが不正な形式である。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "email", "reason": "The email has an invalid form." }
-                      ]
-                    }
-                not_unique_email:
-                  summary: 同じメールアドレスが既に登録されている。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "email", "reason": "The email has already been registered." }
-                      ]
-                    }
-                too_short_password:
-                  summary: パスワードが短すぎる。
-                  value:
-                    {
-                      "status": 422,
-                      "title": "Validation error for user",
-                      "errors": [
-                        { "name": "password", "reason": "The password is too short." }
-                      ]
-                    }
+          $ref: '#/components/responses/unprocessableEntity'
     patch:
       summary: 現在自分がログインしているユーザの情報を更新する
     delete:


### PR DESCRIPTION
# 概要

Unprocessable Entity(422)用のスキーマを共通コンポーネントに追加する。

また、Unprocessable Entityに対応する既存のレスポンスは、先の共通コンポーネントを利用して記述するようリファクタリングする。

# その他

本PRは #8 の後続である。 #8 のマージ後にベースブランチを main に変更する。