### PR TITLE
ファイルのメタデータ更新用のAPIの記述を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -622,6 +622,39 @@ paths:
         - bearer: []
     patch:
       summary: ファイルの情報を更新する
+      operationId: PatchFile
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              description: 必須パラメータ自体は存在しないが、パラメータがない場合はパラメータの不備を理由に400(Bad Request)を返す。
+              type: object
+              properties:
+                name:
+                  $ref: '#/components/schemas/fileName'
+                description:
+                  $ref: '#/components/schemas/fileDescription'
+                file:
+                  $ref: '#/components/schemas/file'
+      responses:
+        '200':
+          description: ファイルの更新に成功したことを意味する。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/fileProperties'
+        '400':
+          $ref: '#/components/responses/bearerBadRequest'
+        '401':
+          $ref: '#/components/responses/bearerUnauthorized'
+        '403':
+          $ref: '#/components/responses/bearerForbidden'
+        '404':
+          $ref: '#/components/responses/notFound'
+        '422':
+          $ref: '#/components/responses/unprocessableEntity'
+      security:
+        - bearer: []
     delete:
       summary: アップロードされているファイルを削除する
     parameters:


### PR DESCRIPTION
# 概要

`/files/<fileId>` へのPATCHリクエストの詳細を記述した。

# その他

本PRは #10 の後続である。 #10 のマージ後にベースブランチを main に変更する。