### PR TITLE
ユーザのメタデータ取得用のAPIの記述の追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -760,7 +760,21 @@ paths:
       - $ref: "#/components/parameters/fileId"
   /user:
     get:
-      summary: 現在自分がログインしているユーザの情報を返す
+      summary: 提供されたトークンに対応するユーザの情報を返す。
+      operationId: GetUser
+      responses:
+        '200':
+          application/json:
+            schema:
+              $ref: '#/components/schemas/userProperties'
+        '400':
+          $ref: '#/components/responses/bearerBadRequest'
+        '401':
+          $ref: '#/components/responses/bearerUnauthorized'
+        '403':
+          $ref: '#/components/responses/bearerForbidden'
+      security:
+        - bearer: []
     post:
       summary: 新しいユーザを作成する
       operationId: CreateUser


### PR DESCRIPTION
# 概要

`/user` エンドポイントへのGETメソッドによる操作のAPIの仕様を記述した。

# その他

本PRは #13 の後続である。 #13 がマージされたのち、ベースブランチを main に変更する。