### PR TITLE
ユーザのメタデータ更新用のAPIの仕様を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -790,6 +790,39 @@ paths:
         '422':
           $ref: '#/components/responses/unprocessableEntity'
     patch:
-      summary: 現在自分がログインしているユーザの情報を更新する
+      summary: 提供されたトークンに対応するユーザの情報を更新する
+      operationId: PatchUser
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              description: 必須パラメータ自体は存在しないが、パラメータがない場合はパラメータの不備を理由に400(Bad Request)を返す。
+              type: object
+              properties:
+                name:
+                  $ref: '#/components/schemas/userName'
+                email:
+                  $ref: '#/components/schemas/userEmail'
+                password:
+                  $ref: '#/components/schemas/userPassword'
+      responses:
+        '200':
+          description: ユーザ情報の更新に成功したことを意味する。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/userProperties'
+        '400':
+          $ref: '#/components/responses/bearerBadRequest'
+        '401':
+          $ref: '#/components/responses/bearerUnauthorized'
+        '403':
+          $ref: '#/components/responses/bearerForbidden'
+        '404':
+          $ref: '#/components/responses/notFound'
+        '422':
+          $ref: '#/components/responses/unprocessableEntity'
+      security:
+        - bearer: []
     delete:
       summary: 現在自分がログインしているユーザの情報を削除する

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -796,7 +796,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              description: 必須パラメータ自体は存在しないが、パラメータがない場合はパラメータの不備を理由に400(Bad Request)を返す。
+              description: パラメータが一つも指定されていない場合は400(Bad Request)を返す。
               type: object
               properties:
                 name:


### PR DESCRIPTION
# 概要

`/user` へのPATCHメソッドに関するAPIの仕様を記述した。

# その他

本PRは #14 の後続である。 #14 がマージされたのち、ベースブランチを main に変更する。