### PR TITLE
ユーザ削除のAPIの仕様を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -792,4 +792,21 @@ paths:
     patch:
       summary: 現在自分がログインしているユーザの情報を更新する
     delete:
-      summary: 現在自分がログインしているユーザの情報を削除する
+      summary: 提供されたトークンに対応するユーザの情報を削除する
+      operationId: DeleteUser
+      responses:
+        '204':
+          description: |
+            ユーザの削除に成功したことを意味する。
+
+            同時に、削除したユーザの資格情報を利用して発行された全トークンは失効される。
+        '400':
+          $ref: '#/components/responses/bearerBadRequest'
+        '401':
+          $ref: '#/components/responses/bearerUnauthorized'
+        '403':
+          $ref: '#/components/responses/bearerForbidden'
+        '404':
+          $ref: '#/components/responses/notFound'
+      security:
+        - bearer: []


### PR DESCRIPTION
# 概要

`/user` へのDELETEメソッドのAPIの仕様を追加した。

# その他

本PRは #15 の後続である。 #15 がマージされた後、ベースブランチを main に変更する。