### PR TITLE
Add the highest `env` key to set env-vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,17 @@ on:
       - main
   pull_request:
 
+env:
+  POSTGRES_PASSWORD: password
+  POSTGRES_USER: root
+
 jobs:
   rspec:
     runs-on: ubuntu-latest
 
-    env:
-      POSTGRES_PASSWORD: password
-      POSTGRES_USER: root
-
     services:
       db:
         image: postgres:15.3-bullseye
-        env:
-          POSTGRES_PASSWORD: password
-          POSTGRES_USER: root
         options: >-
           --health-cmd pg_isready
           --health-interval 10s


### PR DESCRIPTION
# 概要

最上位の `env` キーを利用することで、 `jobs.<job_id>.services.<service_id>.env` にも環境変数の設定が継承されるかどうかを確認する。

# その他

本PRはCIの動作確認を目的としている。そのため、レビュー等は不要である。