### PR TITLE
いくつかの文字列型の値にクォーテーションを追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -586,10 +586,10 @@ paths:
               examples:
                 on_first_page:
                   summary: 先頭ページを返す場合。
-                  value: link: <http://localhost:<PORT>/files?page=2>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"
+                  value: 'link: <http://localhost:<PORT>/files?page=2>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
                 on_middle_page:
                   summary: 中間ページを返す場合。
-                  value: link: <http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"
+                  value: 'link: <http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
           content:
             application/json:
               schema:


### PR DESCRIPTION
# 概要

いくつかの文字列に YAML のキーとして認識される値が含まれている。この値が、 エディタによってはエラーとして認識されるため、クォーテーションを追加して、単なる文字列リテラルであることを明示する。

上記のエラーとして認識するエディタには、例えば Swagger Editor がある。

https://editor-next.swagger.io/