### PR TITLE
エラーレスポンスにおける title フィールドの値に関する説明を追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -205,7 +205,7 @@ components:
               value:
                 {
                   "status": 422,
-                  "title": "Some validation errors for the file",
+                  "title": "Unprocessable Entity",
                   "errors": [
                     { "name": "description", "reason": "Too long" },
                     { "name": "size", "reason": "Too large" }
@@ -241,7 +241,7 @@ components:
                 value:
                   {
                     "status": 400,
-                    "title": "Missing required parameters",
+                    "title": "Bad Request",
                     "error": "invalid_request"
                   }
     bearerUnauthorized:
@@ -278,7 +278,7 @@ components:
               value:
                 {
                   "status": 401,
-                  "title": "An access with an invalid access token",
+                  "title": "Unauthorized",
                   "error": "invalid_token"
                 }
     bearerForbidden:
@@ -315,7 +315,7 @@ components:
               value:
                 {
                   "status": 403,
-                  "title": "The access token only has insufficient scopes",
+                  "title": "Forbidden",
                   "error": "insufficient_scope",
                   "scope": "write"
                 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -154,8 +154,10 @@ components:
       type: string
       description: |
         エラーに関する対人可読な短い説明文が格納される。
+        値は、 `status` フィールドの値であるHTTPステータスに対応する文言(Bad RequestやNot Found等)である。
 
         https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+        https://datatracker.ietf.org/doc/html/rfc7807#section-4.2
     problemDetailsDetail:
       type: string
       description: |


### PR DESCRIPTION
# 概要

エラーレスポンスの形式を Problem details の仕様における title フィールドの値に関する説明を追加する。

# 詳細

Problem Details 形式のエラーには、 type フィールドの値が about:blank であるとき、 title フィールドの値は、その際のHTTPステータスコードを表現する文言(Not Found, Bad Request)等と同じであるべきであるという仕様がある。

また、 Problem Details においてクライアントは、このフィールドが省略されていた場合には、このフィールドの値が about:blank であるとして処理することが必須である。

https://datatracker.ietf.org/doc/html/rfc7807#section-4.2

本APIは現在のところ、エラーレスポンスに type フィールドを含まないため、 title フィールドに関する上記の仕様を満たす必要がある。よって、その仕様に関する説明を追加して明示する。

# その他

~本PRは #24 の後続である。該当PRがマージされた後で、本ブランチをリベースして対応する。~
#24 のマージに伴いリベース済みである。