### PR TITLE
読みやすさのためにテストにコンテキストを追加

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe User, type: :model do
   let(:email) { 'foobar@foo.bar' }
   let(:password) { 'a_little_bit_long_password' }
 
-  it { is_expected.to be_valid }
+  context '値が全て適切であるとき' do
+    it { is_expected.to be_valid }
+  end
 
   describe '.name' do
     context 'nilのとき' do


### PR DESCRIPTION
# 概要

テストの出力と記述上の統一感のために、冗長なコンテキストを追加する。