### PR TITLE
#dupと#saveによるテストデータの作成を変更

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe User, type: :model do
 
     context '同じメールアドレスのユーザが存在する場合' do
       before do
-        user.dup.save!
+        described_class.create! name: Faker::Name.name, email:,
+                                password: Faker::Internet.password(min_length: 16)
       end
 
       it { is_expected.to be_invalid }
@@ -90,9 +91,8 @@ RSpec.describe User, type: :model do
 
     context '大文字小文字違いのメールアドレスを持つユーザが存在する場合' do
       before do
-        another_user = user.dup
-        another_user.email = user.email.upcase
-        another_user.save!
+        described_class.create! name: Faker::Name.name, email: email.upcase,
+                                password: Faker::Internet.password(min_length: 16)
       end
 
       it { is_expected.to be_invalid }


### PR DESCRIPTION
# 概要

#dupでは、id以外の属性が複製されるが、将来、それによりテスト対象ではない属性に関するバリデーションエラーが発生してテストが失敗する可能性もある。ここでは、必ずしも#dupを利用する必要性はないため、#createを利用したユーザ作成に変更する。