### PR TITLE
トップレベルの値の型をオブジェクトに変更

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -549,9 +549,14 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/fileProperties'
+                type: object
+                properties:
+                  files:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/fileProperties'
+                required:
+                  - files
               examples:
                 files:
                   summary: サンプルファイル群


### PR DESCRIPTION
# 概要

一般にJSONの最上位の値の型はオブジェクトのようなので、そのように修正する。

確かに、そのほうが、値を追加しやすかったりするかも。

なお、これはリンターによって指摘された問題である。
https://github.com/IBM/openapi-validator