### PR TITLE
アクセストークン発行用のアクションを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ AllCops:
     - storage/**/*
 
 Metrics/AbcSize:
-  Max: 21
+  Max: 22
   Include:
     - app/controllers/**/*
 
@@ -31,7 +31,7 @@ Metrics/CyclomaticComplexity:
     - app/controllers/**/*
 
 Metrics/MethodLength:
-  Max: 11
+  Max: 12
   CountAsOne:
     - array
     - hash

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,30 @@ AllCops:
     - public/**/*
     - storage/**/*
 
+Metrics/AbcSize:
+  Max: 21
+  Include:
+    - app/controllers/**/*
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+  Include:
+    - app/controllers/**/*
+
+Metrics/MethodLength:
+  Max: 11
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+  Include:
+    - app/controllers/**/*
+
+Metrics/PerceivedComplexity:
+  Max: 10
+  Include:
+    - app/controllers/**/*
+
 RSpec/ExampleLength:
   CountAsOne:
     - array

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,27 +20,12 @@ AllCops:
     - public/**/*
     - storage/**/*
 
-Metrics/AbcSize:
-  Max: 22
-  Include:
-    - app/controllers/**/*
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-  Include:
-    - app/controllers/**/*
-
 Metrics/MethodLength:
   Max: 12
   CountAsOne:
     - array
     - hash
     - heredoc
-  Include:
-    - app/controllers/**/*
-
-Metrics/PerceivedComplexity:
-  Max: 10
   Include:
     - app/controllers/**/*
 

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -9,6 +9,8 @@ class AccessTokensController < ApplicationController
     access_token = current_user.access_tokens.build access_token_params
 
     if access_token.save
+      set_disble_caching_headers
+
       render json: AccessTokenResource.new(access_token)
     elsif access_token.errors.key? :scope
       render problem: { error: 'invalid_scope' }, status: :bad_request
@@ -34,5 +36,10 @@ class AccessTokensController < ApplicationController
 
   def supported_grant_type?
     params[:grant_type] == 'password'
+  end
+
+  def set_disble_caching_headers
+    response.set_header 'Cache-Control', 'no-store'
+    response.set_header 'Pragma', 'no-cache'
   end
 end

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -38,7 +38,7 @@ class AccessTokensController < ApplicationController
   end
 
   def contains_required_params?
-    params.keys.to_set.superset? %w[grant_type username password].to_set
+    %w[grant_type username password].all? { |k| params.key? k }
   end
 
   def supported_grant_type?

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class AccessTokensController < ApplicationController
+  before_action :validate_required_params
+  before_action :validate_grant_type
+
   def post
-    render problem: { error: 'invalid_request' }, status: :bad_request and return unless contains_required_params?
-    render problem: { error: 'unsupported_grant_type' }, status: :bad_request and return unless supported_grant_type?
     render problem: { error: 'invalid_grant' }, status: :bad_request and return if current_user.nil?
 
     access_token = current_user.access_tokens.build access_token_params
@@ -21,6 +22,14 @@ class AccessTokensController < ApplicationController
   end
 
   private
+
+  def validate_required_params
+    render problem: { error: 'invalid_request' }, status: :bad_request unless contains_required_params?
+  end
+
+  def validate_grant_type
+    render problem: { error: 'unsupported_grant_type' }, status: :bad_request unless supported_grant_type?
+  end
 
   def current_user
     @current_user ||= User.find_by(email: params[:username])&.authenticate params[:password]

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -5,9 +5,11 @@ class AccessTokensController < ApplicationController
   before_action :validate_grant_type
 
   def post
-    render problem: { error: 'invalid_grant' }, status: :bad_request and return if current_user.nil?
+    user = User.find_by(email: params[:username])&.authenticate params[:password]
 
-    access_token = current_user.access_tokens.build access_token_params
+    render problem: { error: 'invalid_grant' }, status: :bad_request and return unless user
+
+    access_token = user.access_tokens.build access_token_params
 
     if access_token.save
       set_disble_caching_headers
@@ -29,10 +31,6 @@ class AccessTokensController < ApplicationController
 
   def validate_grant_type
     render problem: { error: 'unsupported_grant_type' }, status: :bad_request unless supported_grant_type?
-  end
-
-  def current_user
-    @current_user ||= User.find_by(email: params[:username])&.authenticate params[:password]
   end
 
   def access_token_params

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class AccessTokensController < ApplicationController
+  def post
+    render problem: { error: 'invalid_request' }, status: :bad_request and return unless contains_required_params?
+    render problem: { error: 'unsupported_grant_type' }, status: :bad_request and return unless supported_grant_type?
+    render problem: { error: 'invalid_grant' }, status: :bad_request and return if current_user.nil?
+
+    access_token = current_user.access_tokens.build access_token_params
+
+    if access_token.save
+      render json: AccessTokenResource.new(access_token)
+    elsif access_token.errors.key? :scope
+      render problem: { error: 'invalid_scope' }, status: :bad_request
+    else
+      render problem: { errors: [{ name: 'access_token', reason: 'can not be created successfully' }] },
+             status:  :internal_server_error
+    end
+  end
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(email: params[:username])&.authenticate params[:password]
+  end
+
+  def access_token_params
+    params.permit :scope
+  end
+
+  def contains_required_params?
+    params.keys.to_set.superset? %w[grant_type username password].to_set
+  end
+
+  def supported_grant_type?
+    params[:grant_type] == 'password'
+  end
+end

--- a/app/resources/access_token_resource.rb
+++ b/app/resources/access_token_resource.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AccessTokenResource
+  include Alba::Resource
+
+  attributes :expires_in, :scope
+
+  attribute :access_token, &:token
+  attribute(:token_type) { 'bearer' }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   post 'user', to: 'users#post'
+  post 'signin', to: 'access_tokens#post'
 end

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -311,23 +311,6 @@ components:
                   "error": "insufficient_scope",
                   "scope": "write"
                 }
-    internalServerError:
-      description: リクエスト自体は正しいが、サーバ上で何らかのエラーが発生し処理ができなかったことを意味する。
-      content:
-        application/problem+json:
-          schema:
-            $ref: '#/components/schemas/error'
-          examples:
-            fail_to_create_access_token:
-              summary: アクセストークンの生成に失敗した。
-              value:
-                {
-                  "status": 500,
-                  "title": "Internal Server Error",
-                  "errors": [
-                    { "name": "access_token", "reason": "can not be created successfully" }
-                  ]
-                }
   parameters:
     fileId:
       name: fileId
@@ -453,8 +436,6 @@ paths:
                   - status
                   - title
                   - error
-        '500':
-          $ref: '#/components/responses/internalServerError'
   /signout:
     post:
       summary: 発行したアクセストークンを失効させる。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -364,7 +364,7 @@ paths:
                   description: 認可サーバに要求するグラントのタイプである。ここではResource Owner Password Credential grant方式を利用するため、値は `password` である必要がある。
                 username:
                   type: string
-                  description: アクセストークンの要求に利用するリソースオーナーのユーザ名である。
+                  description: アクセストークンの要求に利用するリソースオーナーのメールアドレスである。ユーザの表示名ではないことに注意する。
                 password:
                   type: string
                   description: アクセストークンの要求に利用するリソースオーナーのパスワードである。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -365,17 +365,6 @@ paths:
             ログインに成功してアクセストークンが発行されたことを意味する。
 
             https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
-          headers:
-            'Cache-Control':
-              schema:
-                type: string
-                enum:
-                  - no-store
-            'Pragma':
-              schema:
-                type: string
-                enum:
-                  - no-cache
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -311,6 +311,23 @@ components:
                   "error": "insufficient_scope",
                   "scope": "write"
                 }
+    internalServerError:
+      description: リクエスト自体は正しいが、サーバ上で何らかのエラーが発生し処理ができなかったことを意味する。
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            fail_to_create_access_token:
+              summary: アクセストークンの生成に失敗した。
+              value:
+                {
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "errors": [
+                    { "name": "access_token", "reason": "can not be created successfully" }
+                  ]
+                }
   parameters:
     fileId:
       name: fileId
@@ -425,6 +442,8 @@ paths:
                   - status
                   - title
                   - error
+        '500':
+          $ref: '#/components/responses/internalServerError'
   /signout:
     post:
       summary: 発行したアクセストークンを失効させる。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -382,6 +382,17 @@ paths:
             ログインに成功してアクセストークンが発行されたことを意味する。
 
             https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+          headers:
+            'Cache-Control':
+              schema:
+                type: string
+                enum:
+                  - no-store
+            'Pragma':
+              schema:
+                type: string
+                enum:
+                  - no-cache
           content:
             application/json:
               schema:

--- a/spec/requests/access_tokens_spec.rb
+++ b/spec/requests/access_tokens_spec.rb
@@ -43,17 +43,6 @@ RSpec.describe 'AccessTokens', type: :request do
 
         let(:scope) { 'READ' }
 
-        it { is_expected.to have_http_status :success }
-        it { is_expected.to have_attributes media_type: 'application/json' }
-
-        it '値がno-storeであるCache-Controlヘッダを含む' do
-          expect(subject.get_header('Cache-Control')).to eq 'no-store'
-        end
-
-        it '値がno-cacheであるPragmaヘッダを含む' do
-          expect(subject.get_header('Pragma')).to eq 'no-cache'
-        end
-
         it 'リクエストしたscopeの値がレスポンスボディに含まれている' do
           expect(subject.parsed_body).to include(
             'access_token' => user.access_tokens.last.token,

--- a/spec/requests/access_tokens_spec.rb
+++ b/spec/requests/access_tokens_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AccessTokens', type: :request do
+  describe 'POST /signin' do
+    let(:user) { FactoryBot.create :user }
+    let(:grant_type) { 'password' }
+    let(:username) { user.email }
+    let(:password) { user.password }
+
+    context '正当なパラメータを渡したとき' do
+      subject do
+        post signin_path, params: { grant_type:, username:, password: }
+        response
+      end
+
+      it { is_expected.to have_http_status :success }
+      it { is_expected.to have_attributes media_type: 'application/json' }
+
+      it 'レスポンスボディに発行したアクセストークンとそのメタデータを含む' do
+        expect(subject.parsed_body).to include(
+          'access_token' => user.access_tokens.last.token,
+          'token_type'   => 'bearer',
+          'expires_in'   => 1.hour,
+          'scope'        => 'READ WRITE'
+        )
+      end
+
+      context 'パラメータにscopeが含まれているとき' do
+        subject do
+          post signin_path, params: { grant_type:, username:, password:, scope: }
+          response
+        end
+
+        let(:scope) { 'READ' }
+
+        it { is_expected.to have_http_status :success }
+        it { is_expected.to have_attributes media_type: 'application/json' }
+
+        it 'リクエストしたscopeの値がレスポンスボディに含まれている' do
+          expect(subject.parsed_body).to include(
+            'access_token' => user.access_tokens.last.token,
+            'token_type'   => 'bearer',
+            'expires_in'   => 1.hour,
+            'scope'        => scope
+          )
+        end
+      end
+    end
+
+    context '必須パラメータが欠落していたとき' do
+      subject do
+        post signin_path, params: {}
+        response
+      end
+
+      it { is_expected.to have_http_status :bad_request }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+      it { expect(subject.parsed_body).to include 'error' => 'invalid_request' }
+    end
+
+    context '不正な認証情報を渡したとき' do
+      subject do
+        post signin_path, params: { grant_type:, username:, password: }
+        response
+      end
+
+      let(:username) { 'foo' }
+      let(:password) { 'bar' }
+
+      it { is_expected.to have_http_status :bad_request }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+      it { expect(subject.parsed_body).to include 'error' => 'invalid_grant' }
+    end
+
+    context 'サポートしていないgrant_typeを渡したとき' do
+      subject do
+        post signin_path, params: { grant_type:, username:, password: }
+        response
+      end
+
+      let(:grant_type) { 'code' }
+
+      it { is_expected.to have_http_status :bad_request }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+      it { expect(subject.parsed_body).to include 'error' => 'unsupported_grant_type' }
+    end
+
+    context '不正なscopeを渡したとき' do
+      subject do
+        post signin_path, params: { grant_type:, username:, password:, scope: }
+        response
+      end
+
+      let(:scope) { 'foo' }
+
+      it { is_expected.to have_http_status :bad_request }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+      it { expect(subject.parsed_body).to include 'error' => 'invalid_scope' }
+    end
+  end
+end

--- a/spec/requests/access_tokens_spec.rb
+++ b/spec/requests/access_tokens_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe 'AccessTokens', type: :request do
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_attributes media_type: 'application/json' }
 
+      it '値がno-storeであるCache-Controlヘッダを含む' do
+        expect(subject.get_header('Cache-Control')).to eq 'no-store'
+      end
+
+      it '値がno-cacheであるPragmaヘッダを含む' do
+        expect(subject.get_header('Pragma')).to eq 'no-cache'
+      end
+
       it 'レスポンスボディに発行したアクセストークンとそのメタデータを含む' do
         expect(subject.parsed_body).to include(
           'access_token' => user.access_tokens.last.token,
@@ -37,6 +45,14 @@ RSpec.describe 'AccessTokens', type: :request do
 
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_attributes media_type: 'application/json' }
+
+        it '値がno-storeであるCache-Controlヘッダを含む' do
+          expect(subject.get_header('Cache-Control')).to eq 'no-store'
+        end
+
+        it '値がno-cacheであるPragmaヘッダを含む' do
+          expect(subject.get_header('Pragma')).to eq 'no-cache'
+        end
 
         it 'リクエストしたscopeの値がレスポンスボディに含まれている' do
           expect(subject.parsed_body).to include(

--- a/spec/requests/access_tokens_spec.rb
+++ b/spec/requests/access_tokens_spec.rb
@@ -26,13 +26,15 @@ RSpec.describe 'AccessTokens', type: :request do
         expect(subject.get_header('Pragma')).to eq 'no-cache'
       end
 
-      it 'レスポンスボディに発行したアクセストークンとそのメタデータを含む' do
-        expect(subject.parsed_body).to include(
-          'access_token' => user.access_tokens.last.token,
-          'token_type'   => 'bearer',
-          'expires_in'   => 1.hour,
-          'scope'        => 'READ WRITE'
-        )
+      context 'パラメータにscopeが含まれていないとき' do
+        it 'レスポンスボディに発行したアクセストークンとそのメタデータを含む' do
+          expect(subject.parsed_body).to include(
+            'access_token' => user.access_tokens.last.token,
+            'token_type'   => 'bearer',
+            'expires_in'   => 1.hour,
+            'scope'        => 'READ WRITE'
+          )
+        end
       end
 
       context 'パラメータにscopeが含まれているとき' do


### PR DESCRIPTION
# 概要

OAuth 2.0のResource Owner Password Credentials Grantを利用してアクセストークンを発行するアクションを追加する。

- usernameパラメータの値のメールアドレスが送信されることを想定している。
    - このパラメータはOAuth 2.0のRFCにおいて、アクセストークンを発行する際に必須となるパラメータであり、その内容については特に規定されていない。IDとして機能するのであれば仕様上は問題ないと思われる。
- エラーレスポンスについては、返すべき状況とそのパラメータがRFCに記載されている。
    - https://datatracker.ietf.org/doc/html/rfc6749#section-5.2