### PR TITLE
katakata_irbの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /config/master.key
 
 /node_modules/*
+.irb_history

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 /config/master.key
 
 /node_modules/*
-.irb_history
+/.irb_history

--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,1 @@
+require 'katakata_irb' rescue nil

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
   NewCops: disable
   TargetRubyVersion: 3.2
   Exclude:
+    - .irbrc
     - bin/**/*
     - config/*
     - config/environments/*

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem 'brakeman', '~> 6.0', require: false
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'faker', '~> 3.2'
+  gem 'katakata_irb', '~> 0.1.9', require: false
 
   gem 'factory_bot_rails', '~> 6.2'
   gem 'rspec-mocks', '~> 3.12.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
     irb (1.6.4)
       reline (>= 0.3.0)
     json (2.6.3)
+    katakata_irb (0.1.9)
+      irb (>= 1.4.0)
+      rbs
+      reline (>= 0.3.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -180,6 +184,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    rbs (3.1.0)
     regexp_parser (2.8.0)
     reline (0.3.4)
       io-console (~> 0.5)
@@ -251,6 +256,7 @@ DEPENDENCIES
   debug
   factory_bot_rails (~> 6.2)
   faker (~> 3.2)
+  katakata_irb (~> 0.1.9)
   pg (~> 1.1)
   problem_details-rails (~> 0.2.3)
   puma (~> 6.3)


### PR DESCRIPTION
# 概要

某CTOお墨付きのgemでREPL環境を強化だ。

https://www.timedia.co.jp/tech/20230516-tech/

gem_rbs_collectionの導入は別PRで行う予定である。
https://github.com/ruby/gem_rbs_collection

普段コード補完のお世話になっていない人間からすると、少しうるさいような気もするけど、多分すぐに慣れる。