### PR TITLE
katakata_irbにおける型情報の読み込み時の入力ブロックキングを解消する

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,1 +1,3 @@
 require 'katakata_irb' rescue nil
+
+KatakataIrb::Types.loader_type = :async

--- a/.irbrc
+++ b/.irbrc
@@ -1,3 +1,4 @@
 require 'katakata_irb' rescue nil
 
 KatakataIrb::Types.loader_type = :async
+KatakataIrb::Types.preload

--- a/Gemfile
+++ b/Gemfile
@@ -21,11 +21,8 @@ group :development, :test do
   gem 'brakeman', '~> 6.0', require: false
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'faker', '~> 3.2'
+  gem 'katakata_irb', github: 'tompng/katakata_irb', require: false
   gem 'rbs_rails', '~> 0.12.0', require: false
-
-  github 'tompng/katakata_irb' do
-    gem 'katakata_irb', require: false
-  end
 
   gem 'factory_bot_rails', '~> 6.2'
   gem 'rspec-mocks', '~> 3.12.5'

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,11 @@ group :development, :test do
   gem 'brakeman', '~> 6.0', require: false
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'faker', '~> 3.2'
-  gem 'katakata_irb', '~> 0.1.9', require: false
   gem 'rbs_rails', '~> 0.12.0', require: false
+
+  github 'tompng/katakata_irb' do
+    gem 'katakata_irb', require: false
+  end
 
   gem 'factory_bot_rails', '~> 6.2'
   gem 'rspec-mocks', '~> 3.12.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 
 GIT
   remote: https://github.com/tompng/katakata_irb.git
-  revision: c731ff8e7caba5f91fd1085d1a3fddae2e9113cd
+  revision: 2ef74ede1e50544c27cad95731cdb5b5aa1f47fb
   specs:
     katakata_irb (0.1.9)
       irb (>= 1.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,15 @@ GIT
       rubocop-rails (>= 2.14.0)
       rubocop-rspec (>= 2.22.0)
 
+GIT
+  remote: https://github.com/tompng/katakata_irb.git
+  revision: c731ff8e7caba5f91fd1085d1a3fddae2e9113cd
+  specs:
+    katakata_irb (0.1.9)
+      irb (>= 1.4.0)
+      rbs
+      reline (>= 0.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -113,10 +122,6 @@ GEM
     irb (1.6.4)
       reline (>= 0.3.0)
     json (2.6.3)
-    katakata_irb (0.1.9)
-      irb (>= 1.4.0)
-      rbs
-      reline (>= 0.3.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -265,7 +270,7 @@ DEPENDENCIES
   debug
   factory_bot_rails (~> 6.2)
   faker (~> 3.2)
-  katakata_irb (~> 0.1.9)
+  katakata_irb!
   pg (~> 1.1)
   problem_details-rails (~> 0.2.3)
   puma (~> 6.3)


### PR DESCRIPTION
# 概要

リリースされている最新のkatakata_irbでは、型情報を同期読み込みするようで、その結果、irbへの入力が一時的にブロックされることがある。特に、読み込む型情報が多いと、明らかに入力がブロックされるタイミングがあることがわかる。だが、katakata_irbのHEADでは、型情報の遅延読み込みが可能になっている(https://github.com/sls-training/2023-API-training-server/pull/40#discussion_r1244654208) 。よって、これを導入し、快適な補完ライフを手に入れる。

本PRは #41 の事実上の後続である。標準のrbsのみを読み込む場合は、おそらくそれほど読み込みに時間がかからないため、入力がブロックされるという感覚はない。