### PR TITLE
型情報を自動生成する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /node_modules/*
 /.irb_history
 /.gem_rbs_collection/*
+/sig/*

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'faker', '~> 3.2'
   gem 'katakata_irb', '~> 0.1.9', require: false
+  gem 'rbs_rails', '~> 0.12.0', require: false
 
   gem 'factory_bot_rails', '~> 6.2'
   gem 'rspec-mocks', '~> 3.12.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,9 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     rbs (3.1.0)
+    rbs_rails (0.12.0)
+      parser
+      rbs (>= 1)
     regexp_parser (2.8.0)
     reline (0.3.4)
       io-console (~> 0.5)
@@ -267,6 +270,7 @@ DEPENDENCIES
   problem_details-rails (~> 0.2.3)
   puma (~> 6.3)
   rails (~> 7.0.5)
+  rbs_rails (~> 0.12.0)
   rspec-mocks (~> 3.12.5)
   rspec-rails (~> 6.0.2)
   rubocop (~> 1.51)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Install type signatures.
 docker compose exec app bundle exec rbs collection install --frozen
 ```
 
+Generate type signatures for this Rails application.
+
+```sh
+bin/rails rbs_rails:all
+```
+
 ## Test
 
 ```sh

--- a/lib/tasks/rbs.rake
+++ b/lib/tasks/rbs.rake
@@ -1,0 +1,16 @@
+require 'rbs_rails/rake_task'
+
+RbsRails::RakeTask.new do |task|
+  # If you want to avoid generating RBS for some classes, comment in it.
+  # default: nil
+  #
+  # task.ignore_model_if = -> (klass) { klass == MyClass }
+
+  # If you want to change the rake task namespace, comment in it.
+  # default: :rbs_rails
+  # task.name = :cool_rbs_rails
+
+  # If you want to change where RBS Rails writes RBSs into, comment in it.
+  # default: Rails.root / 'sig/rbs_rails'
+  # task.signature_root_dir = Rails.root / 'my_sig/rbs_rails'
+end

--- a/lib/tasks/rbs.rake
+++ b/lib/tasks/rbs.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbs_rails/rake_task'
 
 RbsRails::RakeTask.new do |task|


### PR DESCRIPTION
# 概要

本Railsアプリケーションの型情報をrbs_rails gemを利用して自動生成する。

rbs_rails gemのREADMEに沿ってコマンドを実行するだけで、簡単に型情報を生成可能である。

https://github.com/pocke/rbs_rails

型情報そのものは、現状では共有しなければならない理由がないので、リポジトリには含めない。