### PR TITLE
POST用のアクション名を `create` に変更

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -4,7 +4,7 @@ class AccessTokensController < ApplicationController
   before_action :validate_required_params
   before_action :validate_grant_type
 
-  def post
+  def create
     user = User.find_by(email: params[:username])&.authenticate params[:password]
 
     render problem: { error: 'invalid_grant' }, status: :bad_request and return unless user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  def post
+  def create
     user = User.new user_params
 
     if user.save

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  post 'user', to: 'users#post'
-  post 'signin', to: 'access_tokens#post'
+  post 'user', to: 'users#create'
+  post 'signin', to: 'access_tokens#create'
 end


### PR DESCRIPTION
# 概要

POST用のアクション名が `post` になっていたが、これをRailsアプリケーションで一般的に使われていると思われる `create` に変更する。変更というよりは修正かもしれない。

変更理由は、別のアクションを作っている際に違和感を感じたからである。