### PR TITLE
Gemfile内のgemの指定を単一行に変更する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,12 +29,9 @@ group :development, :test do
   gem 'rspec-rails', '~> 6.0.2'
 
   gem 'rubocop', '~> 1.51', require: false
+  gem 'rubocop-config-timedia', github: 'timedia/styleguide', glob: 'ruby/**/*.gemspec', require: false
   gem 'rubocop-factory_bot', '~> 2.23.1', require: false
   gem 'rubocop-performance', '~> 1.18', require: false
   gem 'rubocop-rails', '~> 2.19.1', require: false
   gem 'rubocop-rspec', '~> 2.22', require: false
-
-  github 'timedia/styleguide', glob: 'ruby/**/*.gemspec' do
-    gem 'rubocop-config-timedia', require: false
-  end
 end


### PR DESCRIPTION
# 概要

複数のgemに同一のオプションを指定するわけでもないので、ブロックを使った記法から、単一行でのgemの指定に切り替える。

こちらのほうが、gemの指定するコマンドのインデントも揃うし、ソートもしやすい。