### PR TITLE
データベースのロケールをC.UTF-8に設定する

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,7 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: root
+      POSTGRES_INITDB_ARGS: --encoding=UTF-8 --locale=C
     volumes:
       - "db-data:${PGDATA:-/var/lib/postgresql/data}"
 


### PR DESCRIPTION
# 概要

アプリケーションとデータベースのロケール(特にLC_COLLATE)が異なると、両者で文字列をソートした際の結果が異なる場合がある。今回であれば、これまでアプリケーションのロケール(およびエンコーディング)はC.UTF-8、 データベースのロケール(およびエンコーディング)はen_US.utf-8になっていた。そのため、例えば `_` と `-` の大小関係が異なっていた。このような差異を解消するために、両者のロケールを統一する。今回は、データベース用のコンテナが環境変数から簡単にデータベースのロケールを設定可能であったため、それを利用してデータベースのロケールをアプリケーションのロケールに合わせる。