### PR TITLE
ページネーション用のメタデータをレスポンスヘッダーに追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'faker', '~> 3.2'
   gem 'katakata_irb', github: 'tompng/katakata_irb', require: false
+  gem 'link-header-parser', '~> 5.0'
   gem 'rbs_rails', '~> 0.12.0', require: false
 
   gem 'factory_bot_rails', '~> 6.2'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '~> 7.0.5'
 
 gem 'active_storage_validations', '~> 1.0.4'
 gem 'alba', '~> 2.3'
+gem 'api-pagination', '~> 5.0'
 gem 'bcrypt', '~> 3.1.18'
 gem 'bootsnap', require: false
 gem 'kaminari', '~> 1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'active_storage_validations', '~> 1.0.4'
 gem 'alba', '~> 2.3'
 gem 'bcrypt', '~> 3.1.18'
 gem 'bootsnap', require: false
+gem 'kaminari', '~> 1.1'
 gem 'pg', '~> 1.1'
 gem 'problem_details-rails', '~> 0.2.3'
 gem 'puma', '~> 6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,18 @@ GEM
     irb (1.6.4)
       reline (>= 0.3.0)
     json (2.6.3)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -281,6 +293,7 @@ DEPENDENCIES
   debug
   factory_bot_rails (~> 6.2)
   faker (~> 3.2)
+  kaminari (~> 1.1)
   katakata_irb!
   pg (~> 1.1)
   problem_details-rails (~> 0.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    link-header-parser (5.0.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -297,6 +298,7 @@ DEPENDENCIES
   faker (~> 3.2)
   kaminari (~> 1.1)
   katakata_irb!
+  link-header-parser (~> 5.0)
   pg (~> 1.1)
   problem_details-rails (~> 0.2.3)
   puma (~> 6.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     alba (2.3.0)
+    api-pagination (5.0.0)
     ast (2.4.2)
     bcrypt (3.1.18)
     bootsnap (1.16.0)
@@ -287,6 +288,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_validations (~> 1.0.4)
   alba (~> 2.3)
+  api-pagination (~> 5.0)
   bcrypt (~> 3.1.18)
   bootsnap
   brakeman (~> 6.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,16 @@
 class ItemsController < ApplicationController
   include Authorization
 
+  def index
+    files = current_user.files
+              .joins(:file_blob)
+              .order(index_orderby_param => index_order_param)
+              .page(index_page_param)
+              .per(index_per_param)
+
+    render json: ItemResource.new(files).serialize(root_key: :files)
+  end
+
   def create
     file = current_user.files.build file_params
 
@@ -17,5 +27,28 @@ class ItemsController < ApplicationController
 
   def file_params
     params.permit :name, :description, :file
+  end
+
+  def index_page_param
+    params[:page]
+  end
+
+  def index_per_param
+    params[:per]
+  end
+
+  def index_orderby_param
+    valid_orderbys = %i[id name description size created_at updated_at]
+    orderby = params[:orderby]&.to_sym
+
+    if valid_orderbys.any? orderby
+      orderby == :size ? 'active_storage_blobs.byte_size' : orderby
+    else
+      :created_at
+    end
+  end
+
+  def index_order_param
+    params.fetch(:order, 'asc') == 'desc' ? :desc : :asc
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
     valid_orderbys = %i[id name description size created_at updated_at]
     orderby = params[:orderby]&.to_sym
 
-    if valid_orderbys.any? orderby
+    if orderby.in? valid_orderbys
       orderby == :size ? 'active_storage_blobs.byte_size' : orderby
     else
       :created_at

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,11 +4,9 @@ class ItemsController < ApplicationController
   include Authorization
 
   def index
-    files = current_user.files
-              .joins(:file_blob)
-              .order(index_orderby_param => index_order_param)
-              .page(index_page_param)
-              .per(index_per_param)
+    files = paginate current_user.files
+                       .joins(:file_blob)
+                       .order(index_orderby_param => index_order_param)
 
     render json: ItemResource.new(files).serialize(root_key: :files)
   end
@@ -27,14 +25,6 @@ class ItemsController < ApplicationController
 
   def file_params
     params.permit :name, :description, :file
-  end
-
-  def index_page_param
-    params[:page]
-  end
-
-  def index_per_param
-    params[:per]
   end
 
   def index_orderby_param

--- a/config/initializers/api_pagination.rb
+++ b/config/initializers/api_pagination.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+ApiPagination.configure do |config|
+  config.page_header = 'Page'
+  config.per_page_header = 'Per'
+
+  config.per_page_param = :per
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :items, as: :files, only: %i[create]
+  resources :items, as: :files, only: %i[index create]
   resource :user, only: %i[create]
   resource :access_token, as: :signin, only: %i[create]
   resource :access_token_revocations, as: :signout, only: %i[create]

--- a/db/migrate/20230704063939_change_record_id_type_to_uuid.rb
+++ b/db/migrate/20230704063939_change_record_id_type_to_uuid.rb
@@ -1,0 +1,8 @@
+class ChangeRecordIdTypeToUuid < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :active_storage_attachments, :record_id
+    add_column :active_storage_attachments, :record_id, :uuid, null: false
+
+    add_index :active_storage_attachments, [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_051521) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_04_063939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -30,9 +30,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_051521) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.uuid "record_id", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -539,6 +539,27 @@ paths:
                 on_middle_page:
                   summary: 中間ページを返す場合。
                   value: '<http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
+            Page:
+              description: 現在のページ数を格納する。
+              schema:
+                type: integer
+                format: int64
+                minimum: 1
+              required: true
+            Per:
+              description: 1ページあたりのファイル数を格納する。
+              schema:
+                type: integer
+                format: int64
+                minimum: 1
+              required: true
+            Total:
+              description: アップロードされているファイル総数を格納する。
+              schema:
+                type: integer
+                format: int64
+                minimum: 0
+              required: true
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -535,10 +535,10 @@ paths:
               examples:
                 on_first_page:
                   summary: 先頭ページを返す場合。
-                  value: 'Link: <http://localhost:<PORT>/files?page=2>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
+                  value: '<http://localhost:<PORT>/files?page=2>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
                 on_middle_page:
                   summary: 中間ページを返す場合。
-                  value: 'Link: <http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
+                  value: '<http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -524,7 +524,7 @@ paths:
         '200':
           description: ユーザがアップロードしたファイル一覧の取得に成功したことを意味する。
           headers:
-            link:
+            Link:
               description: |
                 ページネーション用のリンクを格納する。
 
@@ -535,10 +535,10 @@ paths:
               examples:
                 on_first_page:
                   summary: 先頭ページを返す場合。
-                  value: 'link: <http://localhost:<PORT>/files?page=2>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
+                  value: 'Link: <http://localhost:<PORT>/files?page=2>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
                 on_middle_page:
                   summary: 中間ページを返す場合。
-                  value: 'link: <http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
+                  value: 'Link: <http://localhost:<PORT>/files?page=2>; rel="prev", <http://localhost:<PORT>/files?page=4>; rel="next", <http://localhost:<PORT>/files?page=7>; rel="last", <http://localhost:<PORT>/files?page=1>; rel="first"'
           content:
             application/json:
               schema:

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :item do
+    name { Faker::File.file_name }
+  end
+end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -23,6 +23,24 @@ RSpec.describe 'Items', type: :request do
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_attributes media_type: 'application/json' }
 
+        it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+          links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+          expect(links.relation_types).to include('last', 'next')
+        end
+
+        it 'Pageヘッダーに現在のページ番号が含まれている' do
+          expect(subject.headers.to_h).to include({ 'Page' => '1' })
+        end
+
+        it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+          expect(subject.headers.to_h).to include({ 'Per' => '20' })
+        end
+
+        it 'Totalヘッダーにファイル総数が含まれている' do
+          expect(subject.headers.to_h).to include({ 'Total' => '21' })
+        end
+
         it 'filesキーにアップロード済みファイル一覧が格納される' do
           expect(subject.parsed_body).to include(
             'files' => include(
@@ -71,6 +89,24 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it '1ページ目のファイル一覧を取得する。' do
             first_page_file_ids = user.files.sort_by(&:created_at).take(20).map { |h| h['id'] }
 
@@ -84,6 +120,24 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('first', 'prev')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '2' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it '2ページ目のファイル一覧を取得する。' do
             second_page_file_ids = user.files.sort_by(&:created_at).drop(20).take(20).map { |h| h['id'] }
 
@@ -96,6 +150,24 @@ RSpec.describe 'Items', type: :request do
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
 
           it '1ページ目のファイル一覧を取得する。' do
             first_page_file_ids = user.files.sort_by(&:created_at).take(20).map { |h| h['id'] }
@@ -112,7 +184,7 @@ RSpec.describe 'Items', type: :request do
         end
 
         before do
-          FactoryBot.create_list :item, 20, file:, user:
+          FactoryBot.create_list :item, 21, file:, user:
         end
 
         context '10のとき' do
@@ -120,6 +192,24 @@ RSpec.describe 'Items', type: :request do
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '10' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
 
           it 'ファイル一覧に含まれるファイルの件数は10である。' do
             expect(subject.parsed_body['files']).to have_attributes(size: 10)
@@ -132,6 +222,24 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it 'ファイル一覧に含まれるファイルの件数は20である。' do
             expect(subject.parsed_body['files']).to have_attributes(size: 20)
           end
@@ -142,6 +250,24 @@ RSpec.describe 'Items', type: :request do
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
 
           it 'ファイル一覧に含まれるファイルの件数は20である。' do
             expect(subject.parsed_body['files']).to have_attributes(size: 20)
@@ -156,7 +282,7 @@ RSpec.describe 'Items', type: :request do
         end
 
         before do
-          FactoryBot.create_list :item, 20, file:, user:
+          FactoryBot.create_list :item, 21, file:, user:
         end
 
         context 'ascのとき' do
@@ -165,8 +291,26 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it 'ファイル一覧が昇順にソートされている' do
-            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:created_at).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -178,8 +322,26 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it 'ファイル一覧が降順にソートされている' do
-            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id).reverse
+            sorted_file_ids = user.files.sort_by(&:created_at).drop(1).map(&:id).reverse
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -191,8 +353,26 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it 'ファイル一覧が昇順にソートされている' do
-            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:created_at).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -209,14 +389,32 @@ RSpec.describe 'Items', type: :request do
           let(:orderby) { :id }
 
           before do
-            FactoryBot.create_list :item, 20, file:, user:
+            FactoryBot.create_list :item, 21, file:, user:
           end
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it 'ID順にソートされている' do
-            sorted_file_ids = user.files.sort_by(&:id).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:id).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -226,14 +424,32 @@ RSpec.describe 'Items', type: :request do
           let(:orderby) { :name }
 
           before do
-            FactoryBot.create_list :item, 20, file:, user:
+            FactoryBot.create_list :item, 21, file:, user:
           end
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it '名前順にソートされている' do
-            sorted_file_ids = user.files.sort_by(&:name).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:name).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -243,7 +459,7 @@ RSpec.describe 'Items', type: :request do
           let(:orderby) { :description }
 
           before do
-            FactoryBot.build_list(:item, 20, file:, user:) do |item|
+            FactoryBot.build_list(:item, 21, file:, user:) do |item|
               item.description = Faker::Lorem.characters
               item.save!
             end
@@ -252,8 +468,26 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it '説明文をキーにしてソートされている' do
-            sorted_file_ids = user.files.sort_by(&:description).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:description).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -263,7 +497,7 @@ RSpec.describe 'Items', type: :request do
           let(:orderby) { :size }
 
           before do
-            FactoryBot.build_list(:item, 20, file:, user:).shuffle.each_with_index do |item, i|
+            FactoryBot.build_list(:item, 21, file:, user:).shuffle.each_with_index do |item, i|
               item.file.byte_size = i
               item.save!
             end
@@ -272,8 +506,26 @@ RSpec.describe 'Items', type: :request do
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it 'ファイルサイズをキーにしてソートされている' do
-            sorted_file_ids = user.files.sort_by { |item| item.file.byte_size }.map(&:id)
+            sorted_file_ids = user.files.sort_by { |item| item.file.byte_size }.take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -283,14 +535,32 @@ RSpec.describe 'Items', type: :request do
           let(:orderby) { :created_at }
 
           before do
-            FactoryBot.create_list :item, 20, file:, user:
+            FactoryBot.create_list :item, 21, file:, user:
           end
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it '作成日時をキーにしてソートされている' do
-            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:created_at).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -300,14 +570,32 @@ RSpec.describe 'Items', type: :request do
           let(:orderby) { :updated_at }
 
           before do
-            FactoryBot.create_list(:item, 20, file:, user:).shuffle.each(&:touch)
+            FactoryBot.create_list(:item, 21, file:, user:).shuffle.each(&:touch)
           end
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it '更新日時をキーにしてソートされている' do
-            sorted_file_ids = user.files.sort_by(&:updated_at).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:updated_at).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
           end
@@ -317,16 +605,152 @@ RSpec.describe 'Items', type: :request do
           let(:orderby) { :foo }
 
           before do
-            FactoryBot.create_list :item, 20, file:, user:
+            FactoryBot.create_list :item, 21, file:, user:
           end
 
           it { is_expected.to have_http_status :success }
           it { is_expected.to have_attributes media_type: 'application/json' }
 
+          it 'Linkヘッダーにページネーション用のリンクが含まれている' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '21' })
+          end
+
           it '作成日時をキーにしてソートされている' do
-            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+            sorted_file_ids = user.files.sort_by(&:created_at).take(20).map(&:id)
 
             expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+      end
+
+      context 'ファイル総数が1ページに収まるとき' do
+        subject do
+          get files_path, headers: { Authorization: "Bearer #{access_token.token}" }
+          response
+        end
+
+        before do
+          FactoryBot.create_list :item, 10, file:, user:
+        end
+
+        it { is_expected.to have_http_status :success }
+        it { is_expected.to have_attributes media_type: 'application/json' }
+
+        it 'Linkヘッダーにページネーション関連のリンクが含まれない' do
+          links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+          expect(links.relation_types).not_to include('first', 'last', 'next', 'prev')
+        end
+
+        it 'Pageヘッダーに現在のページ番号が含まれている' do
+          expect(subject.headers.to_h).to include({ 'Page' => '1' })
+        end
+
+        it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+          expect(subject.headers.to_h).to include({ 'Per' => '20' })
+        end
+
+        it 'Totalヘッダーにファイル総数が含まれている' do
+          expect(subject.headers.to_h).to include({ 'Total' => '10' })
+        end
+      end
+
+      context 'ファイル総数が1ページに収まらないとき' do
+        subject do
+          get files_path, params: { page: }, headers: { Authorization: "Bearer #{access_token.token}" }
+          response
+        end
+
+        before do
+          FactoryBot.create_list :item, 41, file:, user:
+        end
+
+        context '最初のページのとき' do
+          let(:page) { 1 }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'Linkヘッダーにページネーション関連のリンクが含まれる' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('last', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '1' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '41' })
+          end
+        end
+
+        context '中間のページのとき' do
+          let(:page) { 2 }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'Linkヘッダーにページネーション関連のリンクが含まれる' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('first', 'last', 'prev', 'next')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '2' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '41' })
+          end
+        end
+
+        context '最後のページのとき' do
+          let(:page) { 3 }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'Linkヘッダーにページネーション関連のリンクが含まれる' do
+            links = LinkHeaderParser.parse subject.headers.fetch('Link', ''), base: "http://#{host}"
+
+            expect(links.relation_types).to include('first', 'prev')
+          end
+
+          it 'Pageヘッダーに現在のページ番号が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Page' => '3' })
+          end
+
+          it 'Perヘッダーに1ページあたりのファイル数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Per' => '20' })
+          end
+
+          it 'Totalヘッダーにファイル総数が含まれている' do
+            expect(subject.headers.to_h).to include({ 'Total' => '41' })
           end
         end
       end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -3,6 +3,437 @@
 require 'rails_helper'
 
 RSpec.describe 'Items', type: :request do
+  describe 'GET /files' do
+    let(:user) { FactoryBot.create :user }
+    let(:access_token) { user.access_tokens.create! scope: 'READ' }
+
+    context '認証に成功したとき' do
+      let(:file) { fixture_file_upload 'empty.txt' }
+
+      context 'パラメータがないとき' do
+        subject do
+          get files_path, headers: { Authorization: "Bearer #{access_token.token}" }
+          response
+        end
+
+        before do
+          FactoryBot.create_list :item, 21, file:, user:
+        end
+
+        it { is_expected.to have_http_status :success }
+        it { is_expected.to have_attributes media_type: 'application/json' }
+
+        it 'filesキーにアップロード済みファイル一覧が格納される' do
+          expect(subject.parsed_body).to include(
+            'files' => include(
+              include(
+                'id'          => anything,
+                'name'        => anything,
+                'description' => anything,
+                'size'        => anything,
+                'created_at'  => anything,
+                'updated_at'  => anything
+              )
+            )
+          )
+        end
+
+        it 'ページ番号1に含まれるファイル一覧が含まれる' do
+          first_page_file_ids = user.files.sort_by(&:created_at).take(20).map(&:id)
+
+          expect(subject.parsed_body['files'].map { |h| h['id'] }).to match_array first_page_file_ids
+        end
+
+        it '含まれるファイル一覧の総数は20である' do
+          expect(subject.parsed_body['files']).to have_attributes(size: 20)
+        end
+
+        it 'created_atの昇順にソートされている' do
+          sorted_file_ids = user.files.sort_by(&:created_at).take(20).map(&:id)
+
+          expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+        end
+      end
+
+      context 'パラメータにpageが含まれているとき' do
+        subject do
+          get files_path, params: { page: }, headers: { Authorization: "Bearer #{access_token.token}" }
+          response
+        end
+
+        before do
+          FactoryBot.create_list :item, 21, file:, user:
+        end
+
+        context '1のとき' do
+          let(:page) { 1 }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '1ページ目のファイル一覧を取得する。' do
+            first_page_file_ids = user.files.sort_by(&:created_at).take(20).map { |h| h['id'] }
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to match_array first_page_file_ids
+          end
+        end
+
+        context '2のとき' do
+          let(:page) { 2 }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '2ページ目のファイル一覧を取得する。' do
+            second_page_file_ids = user.files.sort_by(&:created_at).drop(20).take(20).map { |h| h['id'] }
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to match_array second_page_file_ids
+          end
+        end
+
+        context '不正な値のとき' do
+          let(:page) { 'foo' }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '1ページ目のファイル一覧を取得する。' do
+            first_page_file_ids = user.files.sort_by(&:created_at).take(20).map { |h| h['id'] }
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to match_array first_page_file_ids
+          end
+        end
+      end
+
+      context 'パラメータにperが含まれているとき' do
+        subject do
+          get files_path, params: { per: }, headers: { Authorization: "Bearer #{access_token.token}" }
+          response
+        end
+
+        before do
+          FactoryBot.create_list :item, 20, file:, user:
+        end
+
+        context '10のとき' do
+          let(:per) { 10 }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ファイル一覧に含まれるファイルの件数は10である。' do
+            expect(subject.parsed_body['files']).to have_attributes(size: 10)
+          end
+        end
+
+        context '20のとき' do
+          let(:per) { 20 }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ファイル一覧に含まれるファイルの件数は20である。' do
+            expect(subject.parsed_body['files']).to have_attributes(size: 20)
+          end
+        end
+
+        context '不正な値のとき' do
+          let(:per) { 'foo' }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ファイル一覧に含まれるファイルの件数は20である。' do
+            expect(subject.parsed_body['files']).to have_attributes(size: 20)
+          end
+        end
+      end
+
+      context 'パラメータにorderが含まれているとき' do
+        subject do
+          get files_path, params: { order: }, headers: { Authorization: "Bearer #{access_token.token}" }
+          response
+        end
+
+        before do
+          FactoryBot.create_list :item, 20, file:, user:
+        end
+
+        context 'ascのとき' do
+          let(:order) { 'asc' }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ファイル一覧が昇順にソートされている' do
+            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context 'descのとき' do
+          let(:order) { 'desc' }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ファイル一覧が降順にソートされている' do
+            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id).reverse
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context '不正な値のとき' do
+          let(:order) { 'foo' }
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ファイル一覧が昇順にソートされている' do
+            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+      end
+
+      context 'パラメータにorderbyが含まれているとき' do
+        subject do
+          get files_path, params: { orderby: }, headers: { Authorization: "Bearer #{access_token.token}" }
+          response
+        end
+
+        context 'idのとき' do
+          let(:orderby) { :id }
+
+          before do
+            FactoryBot.create_list :item, 20, file:, user:
+          end
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ID順にソートされている' do
+            sorted_file_ids = user.files.sort_by(&:id).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context 'nameのとき' do
+          let(:orderby) { :name }
+
+          before do
+            FactoryBot.create_list :item, 20, file:, user:
+          end
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '名前順にソートされている' do
+            sorted_file_ids = user.files.sort_by(&:name).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context 'descriptionのとき' do
+          let(:orderby) { :description }
+
+          before do
+            FactoryBot.build_list(:item, 20, file:, user:) do |item|
+              item.description = Faker::Lorem.characters
+              item.save!
+            end
+          end
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '説明文をキーにしてソートされている' do
+            sorted_file_ids = user.files.sort_by(&:description).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context 'sizeのとき' do
+          let(:orderby) { :size }
+
+          before do
+            FactoryBot.build_list(:item, 20, file:, user:).shuffle.each_with_index do |item, i|
+              item.file.byte_size = i
+              item.save!
+            end
+          end
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it 'ファイルサイズをキーにしてソートされている' do
+            sorted_file_ids = user.files.sort_by { |item| item.file.byte_size }.map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context 'created_atのとき' do
+          let(:orderby) { :created_at }
+
+          before do
+            FactoryBot.create_list :item, 20, file:, user:
+          end
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '作成日時をキーにしてソートされている' do
+            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context 'updated_atのとき' do
+          let(:orderby) { :updated_at }
+
+          before do
+            FactoryBot.create_list(:item, 20, file:, user:).shuffle.each(&:touch)
+          end
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '更新日時をキーにしてソートされている' do
+            sorted_file_ids = user.files.sort_by(&:updated_at).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+
+        context '不正な値のとき' do
+          let(:orderby) { :foo }
+
+          before do
+            FactoryBot.create_list :item, 20, file:, user:
+          end
+
+          it { is_expected.to have_http_status :success }
+          it { is_expected.to have_attributes media_type: 'application/json' }
+
+          it '作成日時をキーにしてソートされている' do
+            sorted_file_ids = user.files.sort_by(&:created_at).map(&:id)
+
+            expect(subject.parsed_body['files'].map { |h| h['id'] }).to eq sorted_file_ids
+          end
+        end
+      end
+    end
+
+    context '認証に必要なパラメータが欠落しているとき' do
+      subject do
+        get files_path
+        response
+      end
+
+      it { is_expected.to have_http_status :bad_request }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+
+      it '発生したエラーに関する情報がProblem Detailsに対応したJSON形式でボディに格納される' do
+        expect(subject.parsed_body).to include(
+          'status' => 400,
+          'title'  => 'Bad Request',
+          'error'  => 'invalid_request'
+        )
+      end
+    end
+
+    context 'アクセストークンが存在しないとき' do
+      subject do
+        get files_path, params: {}, headers: { Authorization: "Bearer #{Faker::Alphanumeric.alphanumeric}" }
+        response
+      end
+
+      it { is_expected.to have_http_status :unauthorized }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+
+      it '発生したエラーに関する情報がProblem Detailsに対応したJSON形式でボディに格納される' do
+        expect(subject.parsed_body).to include(
+          'status' => 401,
+          'title'  => 'Unauthorized',
+          'error'  => 'invalid_token'
+        )
+      end
+    end
+
+    context 'アクセストークンが無効化されているとき' do
+      subject do
+        get files_path, params: {}, headers: { Authorization: "Bearer #{access_token.token}" }
+        response
+      end
+
+      before do
+        access_token.revoke
+      end
+
+      it { is_expected.to have_http_status :unauthorized }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+
+      it '発生したエラーに関する情報がProblem Detailsに対応したJSON形式でボディに格納される' do
+        expect(subject.parsed_body).to include(
+          'status' => 401,
+          'title'  => 'Unauthorized',
+          'error'  => 'invalid_token'
+        )
+      end
+    end
+
+    context 'アクセストークンが失効しているとき' do
+      subject do
+        get files_path, params: {}, headers: { Authorization: "Bearer #{access_token.token}" }
+        response
+      end
+
+      before do
+        travel_to access_token.created_at + access_token.expires_in + 1
+      end
+
+      it { is_expected.to have_http_status :unauthorized }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+
+      it '発生したエラーに関する情報がProblem Detailsに対応したJSON形式でボディに格納される' do
+        expect(subject.parsed_body).to include(
+          'status' => 401,
+          'title'  => 'Unauthorized',
+          'error'  => 'invalid_token'
+        )
+      end
+    end
+
+    context 'アクセストークンの権限が不足しているとき' do
+      subject do
+        get files_path, params: {}, headers: { Authorization: "Bearer #{access_token.token}" }
+        response
+      end
+
+      let(:access_token) { user.access_tokens.create! scope: 'WRITE' }
+
+      it { is_expected.to have_http_status :forbidden }
+      it { is_expected.to have_attributes media_type: 'application/problem+json' }
+
+      it '発生したエラーに関する情報がProblem Detailsに対応したJSON形式でボディに格納される' do
+        expect(subject.parsed_body).to include(
+          'status' => 403,
+          'title'  => 'Forbidden',
+          'error'  => 'insufficient_scope',
+          'scope'  => 'READ'
+        )
+      end
+    end
+  end
+
   describe 'POST /files' do
     let(:user) { FactoryBot.create :user }
     let(:access_token) { user.access_tokens.create! scope: 'READ WRITE' }


### PR DESCRIPTION
# 概要

`/files` リソースへのGETアクションのレスポンスヘッダーに、ページネーション用のヘッダーを追加する。

追加するヘッダーの種類や意味は以下のAPI仕様書に記載してある。

https://github.com/sls-training/2023-API-training-server/blob/82a8002f23749f91769e125a6c0b0269d88cdfee/openapi.yaml#L526-L562

# 補足

本PRは #54 の後続である。

 #54 の一部にしてもよかったが、作成されてからしばらく時間が経過してしまったので、別の話題という扱いにした。